### PR TITLE
Remove retry on connection error

### DIFF
--- a/pyexclient/workbench.py
+++ b/pyexclient/workbench.py
@@ -13,7 +13,6 @@ from urllib.parse import urljoin
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.exceptions import ConnectionError
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from urllib3.util.retry import Retry
 
@@ -4909,26 +4908,13 @@ class WorkbenchCoreClient:
             headers['Authorization'] = self.session.headers['Authorization']
             resp = requests.post(url, headers=headers, data=data, files=files, **request_kwargs)
         else:
-            try:
-                resp = self.session.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    data=data,
-                    **request_kwargs
-                )
-            except ConnectionError:
-                # if connection was fatally closed, create a new session and try again
-                logger.warning("got connection error, recreating session...")
-                time.sleep(5)
-                self.make_session()
-                resp = self.session.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    data=data,
-                    **request_kwargs
-                )
+            resp = self.session.request(
+                method=method,
+                url=url,
+                headers=headers,
+                data=data,
+                **request_kwargs
+            )
 
         if self.debug and do_print:
             logger.debug(pprint.pformat(resp.json()))

--- a/pyexclient/workbench.py
+++ b/pyexclient/workbench.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import pprint
-import time
 import warnings
 from urllib.parse import urlencode
 from urllib.parse import urljoin


### PR DESCRIPTION
Credit: @query-ai
Reference: https://github.com/expel-io/pyexclient/pull/47

The Workbench client has a default retry on ConnectionError that was not configurable and could cause unwanted requests (it also waited 5 seconds before retrying). This is not a user friendly approach. Rather than explicitly defining how the client retries, we'll just raise a ConnectionError when it occurs and allow the caller to handle the exception and retry on their own terms.
