### PR TITLE
Ad hoc: Trying another method to pip install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.9"
-
-python:
-  install:
-    - requirements: docs/requirements.txt
+  jobs:
+    post_create_environment:
+      - python -m pip install sphinx_rtd_theme
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-sphinx==5.3.0
-sphinx_rtd_theme==1.1.1
-readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
Found a [thread](https://github.com/readthedocs/sphinx_rtd_theme/issues/923#issuecomment-1780281232) that made me want to try this approach.

I'm not seeing the req.text packages installed here:
https://readthedocs.org/api/v2/build/24482277.txt

i _think_ we get everything else we need out of the box